### PR TITLE
fix JSON syntax

### DIFF
--- a/trax/layers/intro.ipynb
+++ b/trax/layers/intro.ipynb
@@ -16,7 +16,7 @@
         "  1. **Data Stack**: how the Trax runtime manages data streams for the layers\n",
         "  1. **Defining New Layer Classes**: how to define and test your own layer classes\n",
         "  1. **Models**: how to train, evaluate, and run predictions with Trax models\n",
-        "\n",
+        "\n"
       ]
     },
     {
@@ -55,7 +55,7 @@
         "# limitations under the License.\n",
         "\n",
         "import numpy as onp  # np used below for trax.backend.numpy\n",
-        "\n",
+        "\n"
       ]
     },
     {


### PR DESCRIPTION
fix JSON syntax in layers/intro.ipynb so it could be opened by github/colab/jupyter.
Currently there are two additional comas in this file, so it's not valid JSON. It can't be opened neither by github ( https://github.com/google/trax/blob/master/trax/layers/intro.ipynb )  nor by colab.