### PR TITLE
Add funcsigs modules to requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'tensor2tensor',
         'tensorflow-datasets',
         'absl-py',
+        'funcsigs'
     ],
     extras_require={
         'tensorflow': ['tensorflow>=1.14.0'],


### PR DESCRIPTION
On my MacOS machine, after install with `pip install -e .[tensorflow, tests]` and run the examples, it complains about missing module 'funcsigs'.
