### PR TITLE
Allow to use CPU if there is no GPU

### DIFF
--- a/trax/rl/envs/async_trajectory_collector.py
+++ b/trax/rl/envs/async_trajectory_collector.py
@@ -87,7 +87,7 @@ def update_jax_config():
   if FLAGS.use_tpu:
     config.update('jax_platform_name', 'tpu')
   else:
-    config.update('jax_platform_name', 'gpu')
+    config.update('jax_platform_name', '')
 
 
 @gin.configurable(blacklist=[

--- a/trax/rl_trainer.py
+++ b/trax/rl_trainer.py
@@ -101,7 +101,7 @@ def train_rl(
   if FLAGS.use_tpu:
     config.update('jax_platform_name', 'tpu')
   else:
-    config.update('jax_platform_name', 'gpu')
+    config.update('jax_platform_name', '')
 
 
   # TODO(pkozakowski): Find a better way to determine this.


### PR DESCRIPTION
jax_platform_name == '' means try GPU then fall back to CPU.

With this change it's possible to train RL using CPU only. GPU will be used if present.