### PR TITLE
store numpy.array instead of DeviceArray in trajectories

### DIFF
--- a/trax/rl/policy_based_utils.py
+++ b/trax/rl/policy_based_utils.py
@@ -221,8 +221,8 @@ def collect_trajectories(env,
     _, _, dones, env_infos = env.step(
         actions,
         infos={
-            'log_prob_actions': log_probs,
-            'value_predictions': value_preds,
+            'log_prob_actions': log_probs.copy(),
+            'value_predictions': value_preds.copy(),
         })
     env_actions_total_time += (time.time() - t1)
     bare_env_run_time += sum(


### PR DESCRIPTION
This speeds up trajectory collection because extract_info_at_index() in
t2t/.../trjaectory.py now index numpy.array instead of DeviceArray and
it's about 10000x times faster.

I've benchmarked using command:
python trax/rl_trainer.py   --config_file=trax/rl/configs/ppo_acrobot.gin   --train_batch_size=32   --output_dir=/tmp/ppo_acrobot   --alsologtostderr

Epoch time goes down from 84s to 9s per iteration.