### PR TITLE
close SummaryWriters

### DIFF
--- a/trax/rl/actor_critic.py
+++ b/trax/rl/actor_critic.py
@@ -161,6 +161,10 @@ class ActorCriticTrainer(rl_training.PolicyTrainer):
       _copy_model_weights(0, self._n_shared_layers,
                           self._policy_trainer, self._value_trainer)
 
+  def close(self):
+    self._value_trainer.close()
+    super().close()
+
 
 def _copy_model_weights(start, end, from_trainer, to_trainer,  # pylint: disable=invalid-name
                         copy_optimizer_slots=True):

--- a/trax/rl/training.py
+++ b/trax/rl/training.py
@@ -109,6 +109,11 @@ class RLTrainer:
         self._sw.scalar('rl/avg_return', avg_return, step=self._epoch)
         self._sw.flush()
 
+  def close(self):
+    if self._sw is not None:
+      self._sw.close()
+      self._sw = None
+
 
 class PolicyTrainer(RLTrainer):
   """Trainer that uses a deep learning model for policy.
@@ -198,6 +203,10 @@ class PolicyTrainer(RLTrainer):
   def train_epoch(self):
     """Trains RL for one epoch."""
     self._policy_trainer.train_epoch(self._policy_train_steps_per_epoch, 1)
+
+  def close(self):
+    self._policy_trainer.close()
+    super().close()
 
 
 class PolicyGradientTrainer(PolicyTrainer):

--- a/trax/rl_trainer.py
+++ b/trax/rl_trainer.py
@@ -112,6 +112,7 @@ def train_rl(
     task = rl_task.RLTask()
     trainer = light_rl_trainer(task=task, output_dir=output_dir)
     trainer.run(n_epochs)
+    trainer.close()
     return
 
   # TODO(pkozakowski): Find a better way to determine this.

--- a/trax/supervised/trainer_lib.py
+++ b/trax/supervised/trainer_lib.py
@@ -253,6 +253,7 @@ class Trainer(object):
       output_dir: Output directory.
       init_checkpoint: Initial checkpoint to use (default $output_dir/model.pkl)
     """
+    self.close()
     self._output_dir = output_dir
     if output_dir is not None:
       tf.io.gfile.makedirs(output_dir)
@@ -592,6 +593,15 @@ class Trainer(object):
   def _for_n_devices(self, x):
     """Replicates/broadcasts `x` for n devices if `self.n_devicess > 1`."""
     return tl.for_n_devices(x, self.n_devices)  # pylint: disable=protected-access
+
+  def close(self):
+    if self._train_sw is not None:
+      self._train_sw.close()
+      self._train_sw = None
+    if self._eval_sw is not None:
+      self._eval_sw.close()
+      self._eval_sw = None
+
 
 
 @gin.configurable(blacklist=['output_dir'])


### PR DESCRIPTION
SummaryWrites should be closed after use. Otherwise they have some
threads running and prevents application from terminate. Relaying on
garbage collector for this is unstable - sometimes it kills them faster,
sometimes slower.

This fixes https://github.com/google/trax/issues/298

Without this commit, following command does not end (process does not exit):
`python rl_trainer.py   --config_file=rl/configs/light_awr_cartpole.gin  --output_dir=/tmp/awr1`