### PR TITLE
keep default value of max_slice_length in sync with PolicyTrainer.

### DIFF
--- a/trax/rl/actor_critic.py
+++ b/trax/rl/actor_critic.py
@@ -83,7 +83,7 @@ class ActorCriticTrainer(rl_training.PolicyTrainer):
     # to construct value batches which are needed before PolicyTrainer init
     # since policy input creation calls the value model -- hence this code.
     self._task = task
-    self._max_slice_length = kwargs.get('max_slice_length', None)
+    self._max_slice_length = kwargs.get('max_slice_length', 1)
     self._added_policy_slice_length = added_policy_slice_length
 
     # Initialize training of the value function.


### PR DESCRIPTION
`PolicyTrainer.__init__` has default value of `max_slice_length` set to 1 so we the same value should be used as default in `ActorCriticTrainer`