### PR TITLE
Add the general dot operation to Trax NumPy extensions

### DIFF
--- a/trax/tf_numpy/extensions/extensions.py
+++ b/trax/tf_numpy/extensions/extensions.py
@@ -460,7 +460,9 @@ def _minus(a, b):
 
 def _compose_output_rep(lhs_rep, rhs_rep, lhs_contraction, rhs_contraction,
                         lhs_batch, rhs_batch):
-  """ Given lhs representation, rhs representation, contraction and batch dimensions,
+  """ Compose the output string representation.
+
+  Given lhs representation, rhs representation, contraction and batch dimensions,
   compose the output representation.
     e.g., ij, jk, (((1,), (0,)), ((), ())) -> ik
           aij, ajk, (((2,), (1,)), ((0,), (0,))) -> aik
@@ -488,7 +490,9 @@ def _compose_output_rep(lhs_rep, rhs_rep, lhs_contraction, rhs_contraction,
 
 
 def _non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction):
-  """ If it is the general non-batched/single-batched matrix multiplication,
+  """ Compute the non-batched matrix multiplication.
+
+  If it is the general non-batched/single-batched matrix multiplication,
   use the highly optimized kernel `tf.tensordot` to handle it.
 
   Args:
@@ -504,9 +508,10 @@ def _non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction):
 
 
 def tf_dot_general(lhs, rhs, dimension_numbers):
-  """ An equivalent general dot operation as that in JAX -
-     <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
+  """ The general dot operation for TensorFlow.
 
+  An equivalent general dot operation as that in JAX -
+     <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
   Although there is an implementation in TF XLA, avoid directly using XLA when
   possible.
 

--- a/trax/tf_numpy/extensions/extensions.py
+++ b/trax/tf_numpy/extensions/extensions.py
@@ -506,14 +506,15 @@ def _non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction):
 
 
 def tf_dot_general(lhs, rhs, dimension_numbers):
-  """ An equivalent general dot operation as that in JAX -
-     <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
+  """ The general dot operation for TensorFlow.
 
+  An equivalent general dot operation as that in JAX -
+     <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
   Although there is an implementation in TF XLA, avoid directly using XLA when
   possible.
-
-    e.g., non-batched: ij,jk->ik
-          batched: ijk,ikl->ijl
+  
+  e.g., non-batched: ij,jk->ik
+        batched: ijk,ikl->ijl
 
   Args:
     lhs: an array (the left-hand side matrix/vector to be multiplied)

--- a/trax/tf_numpy/extensions/extensions.py
+++ b/trax/tf_numpy/extensions/extensions.py
@@ -506,15 +506,14 @@ def _non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction):
 
 
 def tf_dot_general(lhs, rhs, dimension_numbers):
-  """ The general dot operation for TensorFlow.
-
-  An equivalent general dot operation as that in JAX -
+  """ An equivalent general dot operation as that in JAX -
      <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
+
   Although there is an implementation in TF XLA, avoid directly using XLA when
   possible.
 
-  e.g., non-batched: ij,jk->ik
-        batched: ijk,ikl->ijl
+    e.g., non-batched: ij,jk->ik
+          batched: ijk,ikl->ijl
 
   Args:
     lhs: an array (the left-hand side matrix/vector to be multiplied)
@@ -533,12 +532,12 @@ def tf_dot_general(lhs, rhs, dimension_numbers):
   rhs_rep = char_list[lhs_rank:lhs_rank+rhs_rank]
   contraction, batch = dimension_numbers
   lhs_contraction, rhs_contraction = contraction
-  if not (len(lhs_contraction) == len(rhs_contraction)):
+  if len(lhs_contraction) != len(rhs_contraction):
     raise ValueError("The input matrices are required to have the same number "
                      "of contraction dimensions, but got: lhs {}, rhs: {}".format(
                      len(lhs_contraction), len(rhs_contraction)))
   lhs_batch, rhs_batch = batch
-  if not (len(lhs_batch) == len(rhs_batch)):
+  if len(lhs_batch) != len(rhs_batch):
     raise ValueError("The input matrices are required to have the same number "
                      "of batch dimensions, but got: lhs {}, rhs: {}".format(
                      len(lhs_batch), len(rhs_batch)))
@@ -546,8 +545,8 @@ def tf_dot_general(lhs, rhs, dimension_numbers):
   if len(lhs_batch) == 0 and len(rhs_batch) == 0:
     return _non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction)
 
-  if (lhs_rank == rhs_rank == 3) and (lhs_batch == (0,) and rhs_batch == (0,)) \
-      and (lhs_contraction == (2,) and rhs_contraction == (1,)):
+  if (lhs_rank == rhs_rank == 3 and lhs_batch == (0,) and rhs_batch == (0,)
+      and lhs_contraction == (2,) and rhs_contraction == (1,)):
     return tf.linalg.matmul(lhs, rhs)
 
   for i in range(len(lhs_contraction)):

--- a/trax/tf_numpy/extensions/extensions.py
+++ b/trax/tf_numpy/extensions/extensions.py
@@ -24,6 +24,7 @@ import contextlib
 import threading
 import numpy as np
 import six
+import string
 
 import tensorflow.compat.v2 as tf
 
@@ -451,6 +452,74 @@ def expit(x):
 def erf(x):
   """Computes the Gauss error function of x element-wise."""
   return tf_np.asarray(tf.math.erf(x.data))
+
+
+# Given lhs representation, rhs representation, contraction and batch dimensions,
+# compose the output representation.
+#   e.g., ij, jk, (((1,), (0,)), ((), ())) -> ik
+#         aij, ajk, (((2,), (1,)), ((0,), (0,))) -> aik
+def compose_output_rep(lhs_rep, rhs_rep, lhs_contraction, rhs_contraction,
+                        lhs_batch, rhs_batch):
+  output_rep = []
+  for dim in lhs_batch:
+    output_rep.append(lhs_rep[dim])
+  for dim in rhs_batch:
+    if rhs_rep[dim] not in output_rep:
+      output_rep.append(rhs_rep[dim])
+
+  for i in range(len(lhs_rep)):
+    if i not in lhs_batch and i not in lhs_contraction:
+      output_rep.append(lhs_rep[i])
+  for i in range(len(rhs_rep)):
+    if i not in rhs_batch and i not in rhs_contraction:
+      output_rep.append(rhs_rep[i])
+  return ''.join(output_rep)
+
+
+# If it is the general non-batched/single-batched matrix multiplication,
+# use the highly optimized kernel `tf.tensordot` to handle it.
+def non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction):
+  return tf.tensordot(lhs, rhs, axes=(list(lhs_contraction), list(rhs_contraction)))
+
+
+# An equivalent general dot operation as that in JAX -
+#    <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>
+#
+# Although there is an implementation in TF XLA, avoid directly using XLA when
+# possible.
+#
+#   e.g., non-batched: ij,jk->ik
+#         batched: ijk,ikl->ijl
+def tf_dot_general(lhs, rhs, dimension_numbers):
+
+  char_list = list(string.ascii_lowercase)[8:]
+  lhs_dim, rhs_dim = len(lhs.shape), len(rhs.shape)
+  lhs_rep = char_list[:lhs_dim]
+  rhs_rep = char_list[lhs_dim:lhs_dim+rhs_dim]
+  contraction, batch = dimension_numbers
+  lhs_contraction, rhs_contraction = contraction
+  lhs_batch, rhs_batch = batch
+
+  if len(lhs_batch) == 0 and len(rhs_batch) == 0:
+    return non_batched_matmul(lhs, rhs, lhs_contraction, rhs_contraction)
+
+  cond_a = lhs_dim == rhs_dim == 3
+  cond_b = lhs_batch == (0,) and rhs_batch == (0,)
+  cond_c = lhs_contraction == (lhs_dim - 1,) and rhs_contraction == (1,)
+  if cond_a and cond_b and cond_c:
+    return tf.linalg.matmul(lhs, rhs)
+
+  for i in range(len(lhs_contraction)):
+    rhs_rep[rhs_contraction[i]] = lhs_rep[lhs_contraction[i]]
+  for i in range(len(lhs_batch)):
+    if i < len(rhs_batch):
+      rhs_rep[rhs_batch[i]] = lhs_rep[lhs_batch[i]]
+
+  output_rep = compose_output_rep(lhs_rep, rhs_rep, lhs_contraction,
+                                  rhs_contraction, lhs_batch, rhs_batch)
+  equation = ''.join(lhs_rep) + ',' + ''.join(rhs_rep) + "->" + output_rep
+  return tf.einsum(equation, lhs, rhs)
+
 
 
 def conv(inp,

--- a/trax/tf_numpy/extensions/extensions.py
+++ b/trax/tf_numpy/extensions/extensions.py
@@ -462,10 +462,8 @@ def _compose_output_rep(lhs_rep, rhs_rep, lhs_contraction, rhs_contraction,
                         lhs_batch, rhs_batch):
   """ Compose the output string representation.
 
-  Given lhs representation, rhs representation, contraction and batch dimensions,
-  compose the output representation.
-    e.g., ij, jk, (((1,), (0,)), ((), ())) -> ik
-          aij, ajk, (((2,), (1,)), ((0,), (0,))) -> aik
+  e.g., ij, jk, (((1,), (0,)), ((), ())) -> ik
+        aij, ajk, (((2,), (1,)), ((0,), (0,))) -> aik
 
   Args:
     lhs_rep: A string representation for the left-hand side input array
@@ -515,8 +513,8 @@ def tf_dot_general(lhs, rhs, dimension_numbers):
   Although there is an implementation in TF XLA, avoid directly using XLA when
   possible.
 
-    e.g., non-batched: ij,jk->ik
-          batched: ijk,ikl->ijl
+  e.g., non-batched: ij,jk->ik
+        batched: ijk,ikl->ijl
 
   Args:
     lhs: an array (the left-hand side matrix/vector to be multiplied)

--- a/trax/tf_numpy/extensions/extensions_test.py
+++ b/trax/tf_numpy/extensions/extensions_test.py
@@ -372,22 +372,6 @@ class ExtensionsTest(tf.test.TestCase, parameterized.TestCase):
 
 
   @parameterized.parameters(
-    {"lhs": ['i', 'j'], "rhs": ['j', 'k'], "dims": (((1,), (0,)), ((), ())),
-      "result": "ik"},
-    {"lhs": ['a', 'i', 'j'], "rhs": ['a', 'j', 'k'], "dims": \
-      (((2,), (1,)), ((0,), (0,))), "result": "aik"},
-    {"lhs": ['a', 'b', 'i', 'j'], "rhs": ['a', 'b', 'j', 'k'], "dims": \
-      (((3,), (2,)), ((0, 1,), (0, 1,))), "result": "abik"},
-  )
-  def test_compose_output_rep(self, lhs, rhs, dims, result):
-    contraction, batch = dims
-    lhs_contraction, rhs_contraction = contraction
-    lhs_batch, rhs_batch = batch
-    output_rep = compose_output_rep(lhs, rhs, lhs_contraction, rhs_contraction,
-                                    lhs_batch, rhs_batch)
-    self.assertEqual(output_rep, result)
-
-  @parameterized.parameters(
     {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((3, 2)),
       "dims": (((1,), (0,)), ((), ()))},
     {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((5, 3)),

--- a/trax/tf_numpy/extensions/extensions_test.py
+++ b/trax/tf_numpy/extensions/extensions_test.py
@@ -372,6 +372,22 @@ class ExtensionsTest(tf.test.TestCase, parameterized.TestCase):
 
 
   @parameterized.parameters(
+    {"lhs": ['i', 'j'], "rhs": ['j', 'k'], "dims": (((1,), (0,)), ((), ())),
+      "result": "ik"},
+    {"lhs": ['a', 'i', 'j'], "rhs": ['a', 'j', 'k'], "dims": \
+      (((2,), (1,)), ((0,), (0,))), "result": "aik"},
+    {"lhs": ['a', 'b', 'i', 'j'], "rhs": ['a', 'b', 'j', 'k'], "dims": \
+      (((3,), (2,)), ((0, 1,), (0, 1,))), "result": "abik"},
+  )
+  def test_compose_output_rep(self, lhs, rhs, dims, result):
+    contraction, batch = dims
+    lhs_contraction, rhs_contraction = contraction
+    lhs_batch, rhs_batch = batch
+    output_rep = extensions._compose_output_rep(lhs, rhs, lhs_contraction, rhs_contraction,
+                                    lhs_batch, rhs_batch)
+    self.assertEqual(output_rep, result)
+
+  @parameterized.parameters(
     {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((3, 2)),
       "dims": (((1,), (0,)), ((), ()))},
     {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((5, 3)),

--- a/trax/tf_numpy/extensions/extensions_test.py
+++ b/trax/tf_numpy/extensions/extensions_test.py
@@ -408,9 +408,9 @@ class ExtensionsTest(tf.test.TestCase, parameterized.TestCase):
       "dims": (((4,), (1,)), ((0,), (0,)))},
   )
   def test_tf_dot_general(self, lhs_np, rhs_np, dims):
-    ans = lax.dot_general(jnp.array(lhs_np), jnp.array(rhs_np), dims)
-    result = extensions.tf_dot_general(tf.constant(lhs_np), tf.constant(rhs_np), dims)
-    self.assertTrue((result.numpy() == np.array(ans)).all())
+    ans = lax.dot_general(lhs_np, rhs_np, dims)
+    result = extensions.tf_dot_general(lhs_np, rhs_np, dims)
+    self.assertAllClose(result, np.array(ans))
 
 
   def testConv(self):

--- a/trax/tf_numpy/extensions/extensions_test.py
+++ b/trax/tf_numpy/extensions/extensions_test.py
@@ -28,6 +28,8 @@ import tensorflow.compat.v2 as tf
 
 from trax.tf_numpy import extensions
 import trax.tf_numpy.numpy as tf_np
+from jax import lax
+import jax.numpy as jnp
 
 FLAGS = flags.FLAGS
 
@@ -367,6 +369,49 @@ class ExtensionsTest(tf.test.TestCase, parameterized.TestCase):
     check_trace_only_once(tf_np.asarray(1), tf_np.asarray(2))
     check_trace_only_once(
         tf.convert_to_tensor(value=1), tf.convert_to_tensor(value=2))
+
+
+  @parameterized.parameters(
+    {"lhs": ['i', 'j'], "rhs": ['j', 'k'], "dims": (((1,), (0,)), ((), ())),
+      "result": "ik"},
+    {"lhs": ['a', 'i', 'j'], "rhs": ['a', 'j', 'k'], "dims": \
+      (((2,), (1,)), ((0,), (0,))), "result": "aik"},
+    {"lhs": ['a', 'b', 'i', 'j'], "rhs": ['a', 'b', 'j', 'k'], "dims": \
+      (((3,), (2,)), ((0, 1,), (0, 1,))), "result": "abik"},
+  )
+  def test_compose_output_rep(self, lhs, rhs, dims, result):
+    contraction, batch = dims
+    lhs_contraction, rhs_contraction = contraction
+    lhs_batch, rhs_batch = batch
+    output_rep = compose_output_rep(lhs, rhs, lhs_contraction, rhs_contraction,
+                                    lhs_batch, rhs_batch)
+    self.assertEqual(output_rep, result)
+
+  @parameterized.parameters(
+    {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((3, 2)),
+      "dims": (((1,), (0,)), ((), ()))},
+    {"lhs_np": np.ones((5, 3)), "rhs_np": np.ones((5, 3)),
+      "dims": (((0, 1), (0, 1)), ((), ()))},
+    {"lhs_np": np.ones((5, 3, 2)), "rhs_np": np.ones((2, 3, 2)),
+      "dims": (((1, 2), (1, 0)), ((), ()))},
+    {"lhs_np": np.ones((6, 5, 3)), "rhs_np": np.ones((6, 3, 2)),
+      "dims": (((2,), (1,)), ((0,), (0,)))},
+    {"lhs_np": np.ones((6, 3, 5)), "rhs_np": np.ones((6, 3, 2)),
+      "dims": (((1,), (1,)), ((0,), (0,)))},
+    {"lhs_np": np.ones((5, 3, 2, 2)), "rhs_np": np.ones((5, 2, 2, 6)),
+      "dims": (((2, 3), (1, 2)), ((0,), (0,)))},
+    {"lhs_np": np.ones((2, 2, 5, 3)), "rhs_np": np.ones((2, 2, 3, 2)),
+      "dims": (((3,), (2,)), ((0, 1), (0, 1)))},
+    {"lhs_np": np.ones((2, 2, 5, 2)), "rhs_np": np.ones((2, 2, 3, 2)),
+      "dims": (((3,), (1,)), ((0,), (0,)))},
+    {"lhs_np": np.ones((2, 2, 5, 3, 3)), "rhs_np": np.ones((2, 3, 2, 3, 2)),
+      "dims": (((4,), (1,)), ((0,), (0,)))},
+  )
+  def test_tf_dot_general(self, lhs_np, rhs_np, dims):
+    ans = lax.dot_general(jnp.array(lhs_np), jnp.array(rhs_np), dims)
+    result = extensions.tf_dot_general(tf.constant(lhs_np), tf.constant(rhs_np), dims)
+    self.assertTrue((result.numpy() == np.array(ans)).all())
+
 
   def testConv(self):
     y = extensions.conv(


### PR DESCRIPTION
An equivalent general dot operation as that in JAX - <https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.dot_general.html>

Although there is an implementation in TF XLA, avoid directly using XLA when possible.

e.g., non-batched: ij,jk->ik
        batched: ijk,ikl->ijl