### PR TITLE
Fix data names typo

### DIFF
--- a/docs/source/notebooks/layers_intro.ipynb
+++ b/docs/source/notebooks/layers_intro.ipynb
@@ -946,7 +946,7 @@
         "    my_eval(),  # Takes two args (y_hat, y_target) and has one output (score)\n",
         ")\n",
         "\n",
-        "eval_score = model_plus_eval((xs, targets))\n",
+        "eval_score = model_plus_eval((x, y_target))\n",
         "```"
       ]
     },

--- a/trax/layers/intro.ipynb
+++ b/trax/layers/intro.ipynb
@@ -946,7 +946,7 @@
         "    my_eval(),  # Takes two args (y_hat, y_target) and has one output (score)\n",
         ")\n",
         "\n",
-        "eval_score = model_plus_eval((xs, targets))\n",
+        "eval_score = model_plus_eval((x, y_target))\n",
         "```"
       ]
     },


### PR DESCRIPTION
There seems to be a typo in the example:

```
x, y_target = get_batch_of_labeled_data()

model_plus_eval = Serial(
    my_fancy_deep_model(),  # Takes one arg (x) and has one output (y_hat)
    my_eval(),  # Takes two args (y_hat, y_target) and has one output (score)
)

eval_score = model_plus_eval((xs, targets)) # xs->x, targets->y_target
```