### PR TITLE
Added unit test for LSTMSeq2SeqAttn in the RNN module

### DIFF
--- a/trax/models/rnn_test.py
+++ b/trax/models/rnn_test.py
@@ -45,6 +45,18 @@ class RNNTest(parameterized.TestCase):
       y = model(x)
       self.assertEqual(y.shape, (3, 28, 20))
 
+  def test_lstmseq2seqattn_forward_shape(self, backend):
+    with fastmath.use_backend(backend):
+      model = rnn.LSTMSeq2SeqAttn(
+        input_vocab_size=20,
+        target_vocab_size=20,
+        d_model=16
+      )
+      x = np.ones((3, 28)).astype(np.int32)
+      _, _ = model.init([shapes.signature(x), shapes.signature(x)])
+      ys = model([x, x])
+      self.assertEqual([y.shape for y in ys], [(3, 28, 20), (3, 28)])
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
# Description

Added unit test for `LSTMSeq2SeqAttn` in the `RNN` module.

## Commands

```sh
pip install -e '.[tests]'
pytest trax/models/rnn_test.py
```

## Notes

- I set the same x as both the source and target for simplicity
- I test shapes on all members of the output tuple using the syntax I saw in the LSTM layer test
- I ran into an error with tensorflow numpy backend, and I'm not sure what to make out of it

    ```txt
    TypeError: Loop var args_0_1:0 enters the loop with type <dtype: 'float32'> but has type <dtype: 'float64'> after 1 iteration.
    ```
