### PR TITLE
n_in to 1 in Weights layer

### DIFF
--- a/trax/layers/core.py
+++ b/trax/layers/core.py
@@ -257,7 +257,7 @@ class Weights(base.Layer):
       initializer: Function taking shape and rng as arguments.
       shape: Shape of the learnable weights.
     """
-    super().__init__(name=f'Weights_{shape}', n_in=0, n_out=1)
+    super().__init__(name=f'Weights_{shape}', n_in=1, n_out=1)
     self._shape = shape
     self._initializer = initializer
 


### PR DESCRIPTION
Currently Weights layer take one argument in it's forward function. </br>
It would not be a problem (n_in set to 0 in __init__), but because of it Weights layer can not be used with Parallel and Branch combinators because of _validate function in Parallel. </br>
`      if layers[i].n_in == 0:
        raise ValueError(
            f'Sublayer with n_in = 0 not allowed in Parallel: {layers[i]}')`
</br>
Maybe Weights layer is not intended to be used in these combinators? - I want to use Weights layer to create a model with global bias vector being used in multiple other layers.