### PR TITLE
Remove implicit `object` from the base class

### DIFF
--- a/trax/data/inputs.py
+++ b/trax/data/inputs.py
@@ -533,7 +533,7 @@ def AddLossWeights(id_to_mask=None):  # pylint: disable=invalid-name
 # Note: as we move from Trainer to Loop this class may become obsolete.
 
 
-class Inputs(object):
+class Inputs:
   """Inputs bundle.
 
   Inputs bundle holds input streams and shapes for a training run.

--- a/trax/data/text_encoder.py
+++ b/trax/data/text_encoder.py
@@ -90,7 +90,7 @@ def strip_ids(ids, ids_to_strip):
   return ids
 
 
-class TextEncoder(object):
+class TextEncoder:
   """Base class for converting from ints to/from human readable strings."""
 
   def __init__(self, num_reserved_ids=NUM_RESERVED_TOKENS):
@@ -929,7 +929,7 @@ class SubwordTextEncoder(TextEncoder):
           f.write(subtoken_string + "\n")
 
 
-class ImageEncoder(object):
+class ImageEncoder:
   """Encoder class for saving and loading images."""
 
   def __init__(self, num_reserved_ids=0, height=None, width=None, channels=3):
@@ -1013,7 +1013,7 @@ class ImageEncoder(object):
     return 256
 
 
-class RealEncoder(object):
+class RealEncoder:
   """Encoder class for saving and loading float values."""
 
   def encode(self, s):

--- a/trax/fastmath/ops.py
+++ b/trax/fastmath/ops.py
@@ -52,7 +52,7 @@ class Backend(enum.Enum):
 
 
 # A class that just forwards attribute accesses to backend's numpy object.
-class NumpyBackend(object):
+class NumpyBackend:
   """Numpy functions accelerated to run on GPUs and TPUs. Use like numpy."""
 
   def __getattr__(self, attr):
@@ -61,7 +61,7 @@ class NumpyBackend(object):
 numpy = NumpyBackend()
 
 
-class RandomBackend(object):
+class RandomBackend:
   """Backend providing random functions."""
 
   def get_prng(self, seed):

--- a/trax/jaxboard.py
+++ b/trax/jaxboard.py
@@ -67,7 +67,7 @@ def _pack_images(images, rows, cols):
   return images
 
 
-class SummaryWriter(object):
+class SummaryWriter:
   """Saves data in event and summary protos for tensorboard."""
 
   def __init__(self, log_dir, enable=True):

--- a/trax/optimizers/base.py
+++ b/trax/optimizers/base.py
@@ -20,7 +20,7 @@ from trax import fastmath
 from trax.fastmath import numpy as jnp
 
 
-class Optimizer(object):
+class Optimizer:
   """Base class for optimizers that work hand in hand with Trax layers.
 
   To define an optimizer subclass, specify its behavior with respect to a

--- a/trax/optimizers/trainer.py
+++ b/trax/optimizers/trainer.py
@@ -31,7 +31,7 @@ from trax.fastmath import numpy as jnp
 from trax.layers import combinators as cb
 
 
-class Trainer(object):
+class Trainer:
   """Multi-device accelerated trainer.
 
   Given an optimizer and a composite layer containing model+loss, this class
@@ -206,7 +206,7 @@ def _accelerate_update_fn(forward_and_backward_fn,
   return multi_device_update_fn
 
 
-class ReversibleSerialTrainer(object):
+class ReversibleSerialTrainer:
   """Runs an optimizer on a series of layers, reversible and not.
 
   We provide layers to this trainer in blocks, each block consisting of

--- a/trax/rl/space_serializer.py
+++ b/trax/rl/space_serializer.py
@@ -27,7 +27,7 @@ import gym
 from jax import numpy as np
 
 
-class SpaceSerializer(object):
+class SpaceSerializer:
   """Base class for Gym space serializers.
 
   Attrs:

--- a/trax/rl/task.py
+++ b/trax/rl/task.py
@@ -27,7 +27,7 @@ from trax import fastmath
 from trax.supervised import training
 
 
-class _TimeStep(object):
+class _TimeStep:
   """A single step of interaction with a RL environment.
 
   TimeStep stores a single step in the trajectory of an RL run:
@@ -79,7 +79,7 @@ TimeStepNp = collections.namedtuple('TimeStepNp', [
 ])
 
 
-class Trajectory(object):
+class Trajectory:
   """A trajectory of interactions with a RL environment.
 
   Trajectories are created when interacting with a RL environment. They can

--- a/trax/rl/task_test.py
+++ b/trax/rl/task_test.py
@@ -24,7 +24,7 @@ from trax import test_utils
 from trax.rl import task as rl_task
 
 
-class DummyEnv(object):
+class DummyEnv:
   """Dummy Env class for testing."""
 
   observation_space = gym.spaces.Box(-2, 2, shape=(2,))

--- a/trax/shapes.py
+++ b/trax/shapes.py
@@ -19,7 +19,7 @@ import numpy as np
 import tensorflow as tf
 
 
-class ShapeDtype(object):
+class ShapeDtype:
   """A NumPy ndarray-like object abstracted as shape and dtype.
 
   Main use is for representing input and output signatures.

--- a/trax/supervised/history.py
+++ b/trax/supervised/history.py
@@ -24,7 +24,7 @@ import collections
 from absl import logging
 
 
-class History(object):
+class History:
   """History of metrics.
 
   History contains the metrics recorded during training and evaluation.

--- a/trax/supervised/trainer_lib.py
+++ b/trax/supervised/trainer_lib.py
@@ -70,7 +70,7 @@ _DEFAULT_METRICS = {
 }
 
 
-class Trainer(object):
+class Trainer:
   """Trax trainer.
 
   A trainer allows to make training steps, train for full epochs,


### PR DESCRIPTION
## Description 

This Pull Request removes implicit `object` from the Base Class. 

The Issue seems to be very minor but it improves the readability of the Code and since Python 3 inserts it for us behind the scenes, I suggested that its best remove them up. 

I'm a First-Time Contributor to Google Open-Source so it would be helpful for me understanding how PR workflow works and help me step up in future contributions as well.