### PR TITLE
Fix loading from the model checkpoints for SelfAttention initialized with the masked flag 

### DIFF
--- a/trax/layers/research/efficient_attention.py
+++ b/trax/layers/research/efficient_attention.py
@@ -1062,6 +1062,8 @@ class SelfAttention(base.Layer):
   def init_weights_and_state(self, input_signature):
     if not isinstance(input_signature, (tuple, list)):
       input_signature = (input_signature,)
+    else:
+      input_signature = (input_signature[0],)
     input_signature_unbatched = fastmath.nested_map(
         lambda x: type(x)(shape=x.shape[1:], dtype=x.dtype),
         input_signature)


### PR DESCRIPTION
Only a single input could possibly affect weights and state of the [SelfAttention](https://github.com/google/trax/blob/v1.3.7/trax/layers/research/efficient_attention.py#L932) layer. The use of any other inputs in the [init_weights_and_state](https://github.com/google/trax/blob/v1.3.7/trax/layers/research/efficient_attention.py#L1064) function seems redundant.

At the same time, an instance of SelfAttention [initialized with masked=True](https://github.com/google/trax/blob/v1.3.7/trax/layers/research/efficient_attention.py#L937) fails when being loaded from the model checkpoints. The issue may be solved by ignoring additional inputs (e.g. the optional padding mask).

```python
LayerError: Exception passing through layer CustomCausalMaskedAttention (in init):
  layer created in file [...]/layers/research/efficient_attention.py, line 1009
  layer input shapes: (ShapeDtype{shape:(1, 2048, 128), dtype:float32}, Traced<ShapedArray(bool[1,2048])>with<DynamicJaxprTrace(level=1/0)>)

  File [...]/layers/research/efficient_attention.py, line 1069, in init_weights_and_state
    input_signature)

  File [...]/trax/fastmath/numpy.py, line 109, in nested_map
    return tuple([nested_map(f, y, level=level) for y in obj])

  File [...]/trax/fastmath/numpy.py, line 109, in <listcomp>
    return tuple([nested_map(f, y, level=level) for y in obj])

  File [...]/trax/fastmath/numpy.py, line 102, in nested_map
    return f(obj)

  File [...]/layers/research/efficient_attention.py, line 1068, in <lambda>
    lambda x: type(x)(shape=x.shape[1:], dtype=x.dtype),

TypeError: __init__() got an unexpected keyword argument 'shape'
```


