### PR TITLE
Move matplotlib to the main dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'gym',
         'jax',
         'jaxlib',
+        'matplotlib',
         'numpy',
         'psutil',
         'scipy',
@@ -55,7 +56,6 @@ setup(
         'tests': [
             'attrs',
             'jupyter',
-            'matplotlib',
             'mock',
             'parameterized',
             'pylint',


### PR DESCRIPTION
matplotlib is imported in `trax.jaxboard`, so without this change, the following doesn't work in a fresh environment:

```bash
pip install -e .
python -c 'from trax.supervised import training'
```