### PR TITLE
Allow PretrainedBERT to set attributes required for loading the model from its checkpoints

### DIFF
--- a/trax/models/research/bert.py
+++ b/trax/models/research/bert.py
@@ -312,3 +312,7 @@ class PretrainedBERT(tl.Serial):
     self.weights = jax.tree_unflatten(jax.tree_structure(self.weights), new_w)
     move_to_device = jax.jit(lambda x: x)
     self.weights = jax.tree_map(move_to_device, self.weights)
+
+  def _settable_attrs(self):
+    """We allow to set attributes required for loading the model from its checkpoints."""
+    return (*super()._settable_attrs(), 'init_checkpoint')


### PR DESCRIPTION
This PR for the [issue](https://github.com/google/trax/issues/1655).