### PR TITLE
Add trax.data.Dup combinator

### DIFF
--- a/trax/data/__init__.py
+++ b/trax/data/__init__.py
@@ -45,6 +45,7 @@ from trax.data.inputs import CastTo
 from trax.data.inputs import ConcatenateToLMInput
 from trax.data.inputs import consume_noise_mask
 from trax.data.inputs import CountAndSkip
+from trax.data.inputs import Dup
 from trax.data.inputs import FilterByLength
 from trax.data.inputs import FilterEmptyExamples
 from trax.data.inputs import generate_random_noise_mask

--- a/trax/data/inputs.py
+++ b/trax/data/inputs.py
@@ -235,6 +235,24 @@ def Batch(batch_size):  # pylint: disable=invalid-name
 
 
 @gin.configurable(module='trax.data')
+def Dup():
+  """Duplicates (copies) the top element (inputs).
+
+  The generator stream is augmented in the following way:
+
+  - If the stream consists of a single element `(inputs, )`,
+    the inputs simply get copied to `(inputs, inputs)`.
+  - If the stream consists of multiple elements, for example
+    `(inputs, weights)`, the rest of elements get moved toward
+    the right side `(inputs, inputs, weights)`.
+  """
+  def _copy(xs):
+    x, *rest = xs
+    return (x, x, *rest)
+  return lambda g: map(lambda x: _copy(x), g)
+
+
+@gin.configurable(module='trax.data')
 def FilterEmptyExamples(axes=None, debug=False):  # pylint: disable=invalid-name
   """Filters empty examples.
 


### PR DESCRIPTION
A new `trax.data.Dup` combinator to copy inputs for tasks such as LM.

The generator stream is augmented in the following way:
  - If the stream consists of a single element `(inputs, )`, the inputs simply get copied to `(inputs, inputs)`.
  - If the stream consists of multiple elements, for example `(inputs, weights)`, the rest of elements get moved toward the right side `(inputs, inputs, weights)`.