### PR TITLE
Update trax.supervised.rst - This will now display documentation for all the classes defined inside the file

### DIFF
--- a/docs/source/trax.supervised.rst
+++ b/docs/source/trax.supervised.rst
@@ -5,13 +5,16 @@ decoding
 --------
 
 .. automodule:: trax.supervised.decoding
+   :members:
 
 lr\_schedules
 -------------
 
 .. automodule:: trax.supervised.lr_schedules
+   :members:
 
 training
 --------
 
 .. automodule:: trax.supervised.training
+   :members:


### PR DESCRIPTION
The documentation is not showing up for the classes like TrainTask. This change to .rst file should clear the issue.