### PR TITLE
Correct typo "Engligh" into "English"

### DIFF
--- a/trax/intro.ipynb
+++ b/trax/intro.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "## 1. Run a pre-trained Transformer\n",
         "\n",
-        "Here is how you create an Engligh-German translator in a few lines of code:\n",
+        "Here is how you create an English-German translator in a few lines of code:\n",
         "\n",
         "* create a Transformer model in Trax with [trax.models.Transformer](https://trax-ml.readthedocs.io/en/latest/trax.models.html#trax.models.transformer.Transformer)\n",
         "* initialize it from a file with pre-trained weights with [model.init_from_file](https://trax-ml.readthedocs.io/en/latest/trax.layers.html#trax.layers.base.Layer.init_from_file)\n",


### PR DESCRIPTION
Just a small typo correction, from "Engligh" to "English"