### PR TITLE
fix: broken link in `trax.data` example notebook

### DIFF
--- a/trax/examples/trax_data_Explained.ipynb
+++ b/trax/examples/trax_data_Explained.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/SauravMaheshkar/trax/blob/SauravMaheshkar-example-1/examples/trax_data_Explained.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/google/trax/blob/master/trax/examples/trax_data_Explained.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
Fixes #1744 

I'd contributed the original notebook with a link to my branch of the repository rather than it's expected path.

CC: @afrozenator 